### PR TITLE
Update header links, profile popup and footer layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7,6 +7,8 @@
   text-align: center;
   background-color: #35313B;
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .logo {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,11 +11,13 @@ function App() {
   return (
     <>
       <Header />
-      <Routes>
-        <Route path="/" element={<AdDashboard />} />
-        <Route path="/my-ads" element={<MyAds />} />
-        <Route path="/my-applications" element={<MyApplications />} />
-      </Routes>
+      <main className="flex-grow">
+        <Routes>
+          <Route path="/" element={<AdDashboard />} />
+          <Route path="/my-ads" element={<MyAds />} />
+          <Route path="/my-applications" element={<MyApplications />} />
+        </Routes>
+      </main>
       <Footer />
     </>
   )

--- a/src/components/common/ActionHub/ActionHub.jsx
+++ b/src/components/common/ActionHub/ActionHub.jsx
@@ -69,7 +69,7 @@ const ActionHub = ({ onCreateAd, onFilterChange }) => {
             setSelectedBoss(null);
             setSelectedWorld('');
             onFilterChange({ boss: '', world: '' });
-            setShowCharPopup(true);
+            setActiveMode('create');
             return;
         }
         setActiveMode(mode);
@@ -144,6 +144,7 @@ const ActionHub = ({ onCreateAd, onFilterChange }) => {
                             onCreateAd={handleCreateAd}
                             onWorldSelect={(world) => onFilterChange({ boss: '', world })}
                             charInfo={charInfo}
+                            onCharInfoRequest={() => setShowCharPopup(true)}
                         />
                     </div>
                 )}

--- a/src/components/common/Form/Form.jsx
+++ b/src/components/common/Form/Form.jsx
@@ -7,7 +7,7 @@ import { AuthContext } from '../../../context/AuthContext';
 
 const vocations = ['Sorcerer', 'Druid', 'Knight', 'Paladin', 'Monk'];
 
-const Form = ({ onCreateAd, onWorldSelect, charInfo }) => {
+const Form = ({ onCreateAd, onWorldSelect, charInfo, onCharInfoRequest }) => {
     const [creatures, setCreatures] = useState([]);
     const [soulCore, setSoulCore] = useState(null);
     const [inputValue, setInputValue] = useState('');
@@ -66,7 +66,10 @@ const Form = ({ onCreateAd, onWorldSelect, charInfo }) => {
             return;
         }
 
-        if (!charInfo) return alert('Informe os dados do personagem');
+        if (!charInfo) {
+            onCharInfoRequest && onCharInfoRequest();
+            return;
+        }
 
         const newAd = {
             id: new Date().getTime(),

--- a/src/components/common/Header/Header.jsx
+++ b/src/components/common/Header/Header.jsx
@@ -3,11 +3,8 @@ import { Link, useLocation } from 'react-router-dom';
 import { AuthContext } from '../../../context/AuthContext';
 import UserProfilePopup from './UserProfilePopup';
 
-const navLinks = [
-  { name: 'Home', path: '/' },
-  { name: 'Minhas Vagas', path: '/my-ads' },
-  { name: 'Minhas Aplicações', path: '/my-applications' },
-];
+// Navigation links were moved to the user profile popup
+const navLinks = [];
 
 const Header = ({ children }) => {
   const [menuOpen, setMenuOpen] = useState(false);

--- a/src/components/common/Header/UserProfilePopup.jsx
+++ b/src/components/common/Header/UserProfilePopup.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 const UserProfilePopup = ({ user, onClose, onLogout }) => {
   if (!user) return null;
@@ -18,6 +19,22 @@ const UserProfilePopup = ({ user, onClose, onLogout }) => {
         )}
         <p className="font-bold">{user.displayName || user.email}</p>
         <p className="text-sm text-gray-500 mb-4">{user.email}</p>
+        <div className="flex flex-col gap-2 mb-4">
+          <Link
+            to="/my-ads"
+            onClick={onClose}
+            className="text-[#2B2C30] hover:underline"
+          >
+            Minhas Vagas
+          </Link>
+          <Link
+            to="/my-applications"
+            onClick={onClose}
+            className="text-[#2B2C30] hover:underline"
+          >
+            Minhas Aplicações
+          </Link>
+        </div>
         <button
           onClick={onLogout}
           className="mt-2 bg-[#BF6370] text-white px-4 py-2 rounded w-full hover:bg-[#a94e5b] transition"

--- a/src/index.css
+++ b/src/index.css
@@ -28,8 +28,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- keep navigation links inside user profile
- add route links to profile popup
- adjust create ad flow so char popup triggers from submit
- ensure footer sticks to the bottom of the page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686b27beceac83239a7fecce69f66473