### PR TITLE
Restrict value input to numbers

### DIFF
--- a/src/components/common/Form/Form.jsx
+++ b/src/components/common/Form/Form.jsx
@@ -141,11 +141,13 @@ const Form = ({ onCreateAd, onWorldSelect, charInfo, onCharInfoRequest }) => {
                      Valor pela vaga
                  </label> */}
                 <input
-                    type="text"
+                    type="number"
                     id="value-input"
                     value={inputValue}
                     onChange={(e) => setInputValue(e.target.value)}
-                    placeholder="Ex: 500k"
+                    placeholder="Ex: 50000"
+                    min="0"
+                    step="1"
                     className="w-full p-2 rounded text-black"
                 />
             </div>


### PR DESCRIPTION
## Summary
- enforce numeric-only input for ad value

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d09ea8ee88323b3047e6eb394def9